### PR TITLE
Add Google Tag Manager

### DIFF
--- a/acdocs/docusaurus.config.js
+++ b/acdocs/docusaurus.config.js
@@ -55,6 +55,15 @@ const config = {
     ],
   ],
 
+  plugins: [
+    [
+      '@docusaurus/plugin-google-tag-manager',
+      {
+        containerId: 'GTM-WL2BG9MS',
+      },
+    ],
+  ],
+
   scripts: [
     {
       src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js',

--- a/acdocs/package-lock.json
+++ b/acdocs/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.6.3",
+        "@docusaurus/plugin-google-tag-manager": "^3.6.3",
         "@docusaurus/preset-classic": "3.6.3",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
@@ -3725,7 +3726,6 @@
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.6.3.tgz",
       "integrity": "sha512-1M6UPB13gWUtN2UHX083/beTn85PlRI9ABItTl/JL1FJ5dJTWWFXXsHf9WW/6hrVwthwTeV/AGbGKvLKV+IlCA==",
-      "license": "MIT",
       "dependencies": {
         "@docusaurus/core": "3.6.3",
         "@docusaurus/types": "3.6.3",

--- a/acdocs/package.json
+++ b/acdocs/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.6.3",
+    "@docusaurus/plugin-google-tag-manager": "^3.6.3",
     "@docusaurus/preset-classic": "3.6.3",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",


### PR DESCRIPTION
This adds the Google Tag Manager plugin, we will use tag manager to fire google analytics, insert tracking beacons etc. 